### PR TITLE
makes it so proctor doesnt have to enter access code when enter answers

### DIFF
--- a/app/controllers/proctor_login_controller.rb
+++ b/app/controllers/proctor_login_controller.rb
@@ -24,6 +24,8 @@ class ProctorLoginController < ApplicationController
     pseudonym = Pseudonym.find_by(user_id: params[:user_id])
     @domain_root_account.pseudonym_sessions.create!(pseudonym, false)
     session[:is_proctored] = true
+    quiz = Quizzes::Quiz.find params[:quiz_id]
+    session[:proctor_access_code] = quiz.access_code
     redirect_to "/courses/#{params[:course_id]}/quizzes/#{params[:quiz_id]}/take"
   end
 


### PR DESCRIPTION
long story, canvas expects the access_code to be in the params when you go to take the quiz. This puts in the session which when we then redirect to the quiz a before filter sticks it in the params object.